### PR TITLE
Allow interactive run

### DIFF
--- a/spacescout_labstats/management/commands/run_labstats_daemon.py
+++ b/spacescout_labstats/management/commands/run_labstats_daemon.py
@@ -31,6 +31,11 @@ class Command(BaseCommand):
                     action='store_true',
                     help='This will set the updater to run as a daemon.'),
 
+        make_option('--interactive',
+                    dest='daemon',
+                    action='store_false',
+                    help='This will set the updater to run interactively.'),
+
         make_option('--update-delay',
                     dest='update_delay',
                     type='int',


### PR DESCRIPTION
As far as I can tell, there isn't any way set `daemon` to `False` and therefore avoid forking, without adding another flag. 
