### PR TITLE
Forgot import originally

### DIFF
--- a/spacescout_labstats/endpoints/cte_techloan.py
+++ b/spacescout_labstats/endpoints/cte_techloan.py
@@ -68,6 +68,12 @@ def get_techloan_data():
     req = requests.get(techloan_url +
                        "api/v2/type/?embed=availability&embed=class",
                        verify=False)
+
+    if(req.status_code != 200):
+        logger.warning("CTE Techloan request failed with code: " +
+                       req.status_code)
+        return None
+
     techloan_data = req.json()
 
     try:

--- a/spacescout_labstats/endpoints/seattle_labstats.py
+++ b/spacescout_labstats/endpoints/seattle_labstats.py
@@ -2,6 +2,7 @@ import logging
 from django.conf import settings
 from spacescout_labstats import utils
 from SOAPpy import WSDL
+from SOAPpy.Client import SOAPTimeoutError
 import json
 import traceback
 


### PR DESCRIPTION
Should fix this error:

Traceback (most recent call last):

  File "/data/spacescout/builds/aca-deploy1.s.uw.edu-17/src/spacescoutlabstats/spacescout_labstats/management/commands/run_labstats_daemon.py", line 150, in controller
    self.load_endpoint_data(endpoint)

  File "/data/spacescout/builds/aca-deploy1.s.uw.edu-17/src/spacescoutlabstats/spacescout_labstats/management/commands/run_labstats_daemon.py", line 212, in load_endpoint_data
    endpoint.get_endpoint_data(spaces)

  File "/data/spacescout/builds/aca-deploy1.s.uw.edu-17/src/spacescoutlabstats/spacescout_labstats/endpoints/seattle_labstats.py", line 58, in get_endpoint_data
    except SOAPTimeoutError as ex:

NameError: global name 'SOAPTimeoutError' is not defined


Request repr() unavailable.